### PR TITLE
made the tool work under Dart 2 runtime semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## unreleased
+# Made the tool work under Dart 2 runtime semantics.
+# Updated when we print timing info for the tool.
+
 ## 1.0.0+2
 * Fix an issue converting `DateTime.AUGUST`.
 

--- a/lib/src/dart_fix.dart
+++ b/lib/src/dart_fix.dart
@@ -13,8 +13,6 @@ import 'package:dart2_fix/src/model.dart';
 import 'package:intl/intl.dart';
 import 'package:path/path.dart' as p;
 
-// TODO: audit and simplify code
-
 final NumberFormat _nf = new NumberFormat('0.0');
 
 Future<ExitResult> dartFix(List<String> args) async {
@@ -100,10 +98,12 @@ Future<ExitResult> dartFixInternal(
 
     String suffix = performDryRun ? '' : '; no changes applied';
 
+    double seconds = stopwatch.elapsedMilliseconds / 1000.0;
     return new ExitResult(
         1,
         'Found ${issues.errors.length} analysis ${_pluralize(
-            issues.errors.length, 'error', 'errors')}$suffix.');
+            issues.errors.length, 'error', 'errors')}$suffix (in ${_nf.format(
+            seconds)}s).');
   }
 
   ChangeManager changeManager = ChangeManager.create();

--- a/lib/src/deprecation_analysis_server.dart
+++ b/lib/src/deprecation_analysis_server.dart
@@ -67,11 +67,14 @@ class DeprecationLocator {
     await completer.future;
 
     List<String> sources = errorMap.keys.toList();
-    List<AnalysisError> errors =
-        sources.map((String key) => errorMap[key]).fold([], (List a, List b) {
-      a.addAll(b);
-      return a;
-    }).toList();
+    List<AnalysisError> errors = sources
+        .map((String key) => errorMap[key])
+        .fold([], (List a, List b) {
+          a.addAll(b);
+          return a;
+        })
+        .toList()
+        .cast<AnalysisError>();
 
     DeprecationResults results = new DeprecationResults([], []);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: '>=1.20.1 <2.0.0'
 
 dependencies:
-  analysis_server_lib: ^0.1.3
+  analysis_server_lib: ^0.1.4
   analyzer: 0.31.2-alpha.1
   args: ^1.4.0
   cli_util: ^0.1.2


### PR DESCRIPTION
- made the tool work under Dart 2 runtime semantics
- updated when we print timing info for the tool (fix https://github.com/dart-lang/dart2_fix/issues/9)

@scheglov 