### PR TITLE
add the ability to check packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,4 +99,3 @@ kinds of conflicts, the following top level members have been added to
 Please file feature requests and bugs at the [issue tracker][tracker].
 
 [tracker]: https://github.com/dart-lang/dart2_fix/issues
-


### PR DESCRIPTION
- add the ability to check packages
- fix https://github.com/dart-lang/dart2_fix/issues/22

This adds a cli option - `--check-package=<package name>` - which:
- gets the package repo url from pub.dartlang.org
- clones it into a sub directory
- runs pub get
- and, either checks the package for deprecated constants, or applies the automated refactorings

@scheglov 

